### PR TITLE
Write JSON Feature

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -134,3 +134,24 @@ Note that for the `extends` statement, the path is going to be relative.
 Also note that in the index page, we have removed `post.content`, as the content is going on it's own page, and would now also be surrounded by the layout. If you want a "preview" or "snippet" of the blog post, you should add that directly to the front matter. Taking a slice of the markup is usually a bad idea anyway, as you can slice in the middle of an open tag and it will mess up the rest of your page (for example, if you cut your snippet off in the middle of a bold tag before it closes, the rest of your page will be bold). For blog post snippets, you want to go with just plain text, which is better suited to the front matter than the body of the file.
 
 Now when we hit the url, we'll see the post rendered into a layout as it should be. You'll see the special property `post._url` as mentioned earlier, which simply prints a path to the post, including the deep-nesting if present. You might have also noticed the special `_content` key being set to false in the post file. This will just remove `post.content`, since we are no longer using it, and the full post contents with the full layout times a bunch of posts can be a very lengthy unused value. While you certainly can get away with not including this special key, if you are not planning on using `post.contents` on your index page, it's recommended that you just cut it for cleanliness and speed.
+
+### Exporting Dynamic Content as JSON
+
+For some use cases, you may want to have your dynamic content available to be accessed by javascript in reaction to a user's action. For example, you might want to load your first five blog posts onto the index, but wait until the user hits "next page" to load in the rest. There are two ways you can do this.
+
+First, you can just stringify the `site` object into a script tag, and use it from there. It would look something like this, in jade:
+
+```jade
+p here's my great page
+script!= "window.dynamic_content = " + JSON.stringify(site)
+```
+
+In other situations, this might not make the cut -- for example if you are trying to access other dynamic content from within a single piece of dynamic content, all of the other ones might not be finished rendering when that particular one renders, so you can't guarantee they will all be present. For use cases like this, you can simply have this extension export all dynamic content to a JSON file that you can then pull with javascript. To do this, just pass a `write` key to the extension's initialization with the value being a path you want to write the json to (written relative to the public folder). So, for example:
+
+```
+extensions: [
+  dynamic_content(write: 'content.json')
+]
+```
+
+This would write all your dynamic content to `public/content.json` whenever the project compiles.

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -6,107 +6,118 @@ yaml = require 'js-yaml'
 W    = require 'when'
 helpers = require './helpers'
 
-class DynamicContent
-  constructor: ->
-    @category = 'dynamic'
+module.exports = (opts = {}) ->
 
-  fs: ->
-    extract: true
-    ordered: true
-    detect: (f) -> helpers.detect_file(f.path)
+  class DynamicContent
+    constructor: ->
+      @category = 'dynamic'
+      @all_content = []
 
-  compile_hooks: ->
-    before_pass: before_hook.bind(@)
-    after_file: after_hook.bind(@)
-    write: write_hook.bind(@)
+    fs: ->
+      extract: true
+      ordered: true
+      detect: (f) -> helpers.detect_file(f.path)
 
-  ###*
-   * For dynamic files before the last compile pass:
-   * - remove the front matter, parse into an object
-   * - add the object to the locals, nesting as deep as the folder it's in
-   * - add an "all" utility function to each level
-   *
-   * @private
-   *
-   * @param  {Object} ctx - roots context
-  ###
+    compile_hooks: ->
+      before_pass: before_hook.bind(@)
+      after_file: after_hook.bind(@)
+      write: write_hook.bind(@)
 
-  before_hook = (ctx) ->
-    # if last pass
-    if ctx.index is ctx.file.adapters.length
-      f = ctx.file
-      roots = f.roots
+    category_hooks: ->
+      after: after_category.bind(@)
 
-      data         = helpers.read(ctx.content)
-      front_matter = _.omit(data, 'content')
-      ctx.content  = data.content
+    ###*
+     * For dynamic files before the last compile pass:
+     * - remove the front matter, parse into an object
+     * - add the object to the locals, nesting as deep as the folder it's in
+     * - add an "all" utility function to each level
+     *
+     * @private
+     *
+     * @param  {Object} ctx - roots context
+    ###
 
-      # get categories and per-compile locals, add or define site key
-      folders = path.dirname(f.file.relative).split(path.sep)
-      locals = f.compile_options.site ?= {}
-      file_locals = f.file_options
+    before_hook = (ctx) ->
+      # if last pass
+      if ctx.index is ctx.file.adapters.length
+        f = ctx.file
+        roots = f.roots
 
-      # add special keys for url and categories
-      front_matter._categories = folders
-      front_matter._url = roots.config.out(f.file, ctx.adapter.output)
-                            .replace(roots.config.output_path(), '')
+        data         = helpers.read(ctx.content)
+        front_matter = _.omit(data, 'content')
+        ctx.content  = data.content
 
-      # deep nested dynamic content
-      # - make sure the backtraced path to a deep-nested folder exists
-      # - push the front matter to the folder name array/object
-      # - add special 'all' function to the array/object
-      # - save pointer to the front matter obj under file-specific post local
-      for f, i in folders
-        locals[f] ?= []
-        locals = locals[f]
-        if i is folders.length - 1
-          locals.push(front_matter)
-          locals.all = all_fn
-          file_locals.post = locals[locals.length - 1]
+        # get categories and per-compile locals, add or define site key
+        folders = path.dirname(f.file.relative).split(path.sep)
+        locals = f.compile_options.site ?= {}
+        file_locals = f.file_options
 
-  ###*
-   * After a file in the category has been compiled, grabs the content and
-   * adds it to the locals object unless _content key is false
-   *
-   * @private
-   *
-   * @param  {Object} ctx - roots context
-   * @return {Boolean}
-  ###
+        # add special keys for url and categories
+        front_matter._categories = folders
+        front_matter._url = roots.config.out(f.file, ctx.adapter.output)
+                              .replace(roots.config.output_path(), '')
 
-  after_hook = (ctx) ->
-    locals = ctx.file_options.post
-    locals.content = ctx.content unless locals._content is false
+        # deep nested dynamic content
+        # - make sure the backtraced path to a deep-nested folder exists
+        # - push the front matter to the folder name array/object
+        # - add special 'all' function to the array/object
+        # - save pointer to the front matter obj under file-specific post local
+        for f, i in folders
+          locals[f] ?= []
+          locals = locals[f]
+          if i is folders.length - 1
+            locals.push(front_matter)
+            @all_content.push(front_matter)
+            locals.all = all_fn
+            file_locals.post = locals[locals.length - 1]
 
-  ###*
-   * If a dynamic file has `_render` set to false in the locals, don't write
-   * the file. Otherwise write as usual.
-   *
-   * @param  {Object} ctx - roots context
-   * @return {Boolean} whether or not to write the file as usual
-  ###
+    ###*
+     * After a file in the category has been compiled, grabs the content and
+     * adds it to the locals object unless _content key is false
+     *
+     * @private
+     *
+     * @param  {Object} ctx - roots context
+     * @return {Boolean}
+    ###
 
-  write_hook = (ctx) ->
-    ctx.file_options.post._render isnt false
+    after_hook = (ctx) ->
+      locals = ctx.file_options.post
+      locals.content = ctx.content unless locals._content is false
 
-  ###*
-   * Returns an array of all the dynamic content object in the folder
-   * it was called on, as well as every folder nested under it, flattened
-   * into a single array.
-   *
-   * @private
-   *
-   * @return {Array} Array of dynamic content objects
-  ###
+    after_category = (ctx) ->
+      if opts.write
+        destination = path.join(ctx.roots.config.output_path(), opts.write)
+        fs.writeFileSync(destination, JSON.stringify(@all_content))
 
-  all_fn = ->
-    values = []
-    recurse = (obj) ->
-      for o in Object.keys(obj)
-        if not isNaN(parseInt(o)) then values.push(obj[o]); continue
-        recurse(obj[o])
-    recurse(this)
-    values
+    ###*
+     * If a dynamic file has `_render` set to false in the locals, don't write
+     * the file. Otherwise write as usual.
+     *
+     * @param  {Object} ctx - roots context
+     * @return {Boolean} whether or not to write the file as usual
+    ###
 
-module.exports = -> DynamicContent
+    write_hook = (ctx) ->
+      ctx.file_options.post._render isnt false
+
+    ###*
+     * Returns an array of all the dynamic content object in the folder
+     * it was called on, as well as every folder nested under it, flattened
+     * into a single array.
+     *
+     * @private
+     *
+     * @return {Array} Array of dynamic content objects
+    ###
+
+    all_fn = ->
+      values = []
+      recurse = (obj) ->
+        for o in Object.keys(obj)
+          if not isNaN(parseInt(o)) then values.push(obj[o]); continue
+          recurse(obj[o])
+      recurse(this)
+      values
+
 module.exports.Helpers = helpers

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "when": "3.x"
   },
   "devDependencies": {
-    "coffee-script": "1.7.x",
-    "mocha": "*",
+    "coffee-script": "1.8.x",
+    "mocha": "2.x",
     "should": "*",
     "coffeelint": "*",
     "istanbul": "*",
     "mocha-lcov-reporter": "*",
     "coveralls": "*",
-    "roots": "3.0.0-rc.10",
+    "roots": "3.x",
     "roots-util": "0.1.x"
   },
   "scripts": {

--- a/test/fixtures/write_json/app.coffee
+++ b/test/fixtures/write_json/app.coffee
@@ -1,0 +1,9 @@
+dynamic_content = require '../../..'
+
+module.exports =
+  ignores: ["**/_*"]
+
+  extensions: [dynamic_content(write: 'content.json')]
+
+  jade:
+    pretty: true

--- a/test/fixtures/write_json/index.jade
+++ b/test/fixtures/write_json/index.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(site.posts.all())

--- a/test/fixtures/write_json/package.json
+++ b/test/fixtures/write_json/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/fixtures/write_json/posts/_layout.jade
+++ b/test/fixtures/write_json/posts/_layout.jade
@@ -1,0 +1,5 @@
+doctype html
+head
+  title testing
+body
+  block content

--- a/test/fixtures/write_json/posts/test.jade
+++ b/test/fixtures/write_json/posts/test.jade
@@ -1,0 +1,6 @@
+---
+title: 'other test'
+_render: false
+---
+
+p another test

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -93,6 +93,16 @@ describe 'dynamic content', ->
     content = JSON.parse(fs.readFileSync(p, 'utf8'))
     content.post.wow.should.eql('amaze')
 
+describe 'write_json', ->
+
+  before (done) -> compile_fixture.call(@, 'write_json', -> done())
+
+  it 'should write content to json file if specified', (done) ->
+    p = path.join(@public, 'content.json')
+    h.file.exists(p).should.be.ok
+    h.file.contains_match(p, /another test/).should.be.ok
+    done()
+
 describe 'helpers', ->
   describe 'readdir', ->
     it 'should read dynamic content files in the directory', (done) ->


### PR DESCRIPTION
This PR adds an option to the plugin in which you can specify a path to which the extension will write the full contents of all your dynamic content as json. This allows you to guarantee the full contents can be pulled with javascript, which isn't always possible if you are trying to access other content inside a single piece of dynamic content, since they all render in a random order as quickly as possible.