### PR TITLE
Using os.EOL is not a good decision for front matter matching.

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -2,9 +2,12 @@ fs     = require 'fs'
 path   = require 'path'
 W      = require 'when'
 nodefn = require 'when/node'
-os     = require 'os'
 yaml   = require 'js-yaml'
 _      = require 'lodash'
+
+BR = "(?:\\\r\\\n|\\\n|\\\r)" # cross-platform newline
+LINEBREAK_REGEXP = new RegExp(BR)
+FRONTMATTER_REGEXP = new RegExp(///^---\s*#{BR}([\s\S]*?)#{BR}?---\s*#{BR}?///)
 
 ###*
  * Read the first three bytes of each file, if they are '---', assume
@@ -17,7 +20,7 @@ _      = require 'lodash'
 ###
 
 detect = (str) ->
-  if str.split(os.EOL.substring(0,1))[0] == '---' then true else false
+  if str.split(LINEBREAK_REGEXP)[0] == '---' then true else false
 
 detect_file = (path) ->
   deferred = W.defer()
@@ -32,9 +35,7 @@ detect_file = (path) ->
 
 read = (str) ->
   if not detect(str) then return false
-  br = "\\#{os.EOL}" # cross-platform newline
-  regex = new RegExp(///^---\s*#{br}([\s\S]*?)#{br}?---\s*#{br}?///)
-  front_matter_str = str.match(regex)
+  front_matter_str = str.match(FRONTMATTER_REGEXP)
   data = yaml.safeLoad(front_matter_str[1])
   data.content = str.replace(front_matter_str[0], '')
   return data

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -138,6 +138,28 @@ describe 'helpers', ->
       res.test.should.eql 'foo'
       res.content.should.eql 'sweet content\n'
 
+    it 'should read front matter from a string without content and no newline at the end with windows style line endings', ->
+      test = "---\r\ntest: 'foo'\r\n---"
+      res = helpers.read(test)
+      res.test.should.eql 'foo'
+      res.content.should.eql ''
+
+    it 'should read dynamic content regardless of newline style', ->
+      test = "---\ntest: 'foo'\n---\nsweet content\n"
+      res = helpers.read(test)
+      res.test.should.eql 'foo'
+      res.content.should.eql 'sweet content\n'
+	  
+      test = "---\r\ntest: 'foo'\r\n---\r\nsweet content\r\n"
+      res = helpers.read(test)
+      res.test.should.eql 'foo'
+      res.content.should.eql 'sweet content\r\n'
+	  
+      test = "---\rtest: 'foo'\r---\rsweet content\r"
+      res = helpers.read(test)
+      res.test.should.eql 'foo'
+      res.content.should.eql 'sweet content\r'
+
     it "should return false if it's not formatted as dynamic content", ->
       test = "this ain't dynamic content doge"
       res = helpers.read(test).should.eql false


### PR DESCRIPTION
os.EOL was not correctly used in the regexes and is not a good overall choice: when you check out a file with Linux style line endings on a Windows machine or vice versa you end up with errors and I would argue this not an uncommon case.

On to the more subtle problems on Windows machines in the usage as done in this library:
1. `br = "\\#{os.EOL}" `: you only escape the first char of the EOL string. (on Windows `os.EOL` is `'\r\n'`)
2. `os.EOL.substring(0,1)` does not match Linux style line endings on Windows machines and vice versa.
3. `#{br}?`: you make only the second char the EOL string optional which leads to front matter not being detected on Windows machines when the file does not end with an EOL (e.g.: `---\r\ntest: 'foo'\r\n---`)